### PR TITLE
ERA-847 avoid remaking target after daml start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DAML_SRC=$(shell find src/ -name '*.daml')
 TS_SRC=$(shell find ui/src/ -name '*.ts*')
 
-DAR=.daml/dist/supplychain-1.0.0.dar
+DAR=target/supplychain-1.0.0.dar
 JS_CODEGEN_DIR=daml.js
 JS_CODEGEN_ARTIFACT=$(JS_CODEGEN_DIR)/supplychain-1.0.0/package.json
 UI_INSTALL_ARTIFACT=ui/node_modules


### PR DESCRIPTION
While I'm very much against having two DAR files, this change optimizes the build after a `daml start`. This command updates the timestamp on `.daml/**/*dar`, forcing `make` to update the target. So let's ignore `.daml` in the build process completely.
After this change, after a `make build && daml start`, another round won't recreate the artifacts. 